### PR TITLE
Allow setting currency options per conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ const toWords = new ToWords({
     ignoreDecimal: false,
     ignoreZeroCurrency: false,
     doNotAddOnly: false,
+    currencyOptions: { // can be used to override defaults for the selected locale
+      name: 'Rupee',
+      plural: 'Rupees',
+      symbol: '₹',
+      fractionalUnit: {
+        name: 'Paisa',
+        plural: 'Paise',
+        symbol: '',
+      },
+    }
   }
 });
 ```
@@ -90,6 +100,7 @@ let words = toWords.convert(0.572, { currency: true, ignoreZeroCurrency: true })
 | ignoreDecimal | boolean | false | Whether to ignore fractional unit of number while converting into words. |
 | ignoreZeroCurrency | boolean | false | Whether to ignore zero currency value while converting into words. |
 | doNotAddOnly | boolean | false | Do not add `only` at the end of the words. This works only when currency = true |
+| currencyOptions | object | undefined | By default currency options are taken from the specified locale.<br/>This option allows to specify different currency options while keeping the language details from the selected locale (e.g. convert to English text but use EUR as a currency). You can define different currencies for each call to `convert()` so it works also if you need to dynamically support multiple currencies.<br/>*This works only when `currency = true`* | 
 
 ## Supported Locale
 | Country  | Language | Locale |

--- a/__tests__/en-US.test.ts
+++ b/__tests__/en-US.test.ts
@@ -233,3 +233,34 @@ describe('Test Floats with options = { currency: true, ignoreZeroCurrency: true,
     },
   );
 });
+
+const testFloatsWithEuroCurrency = [
+  [0.0, `Zero Euros Only`],
+  [0.04, `Zero Euros And Four Eurocents Only`],
+  [0.0468, `Zero Euros And Five Eurocents Only`],
+  [0.4, `Zero Euros And Forty Eurocents Only`],
+  [0.63, `Zero Euros And Sixty Three Eurocents Only`],
+  [0.973, `Zero Euros And Ninety Seven Eurocents Only`],
+  [0.999, `One Euros Only`],
+  [37.06, `Thirty Seven Euros And Six Eurocents Only`],
+  [37.068, `Thirty Seven Euros And Seven Eurocents Only`],
+  [37.68, `Thirty Seven Euros And Sixty Eight Eurocents Only`],
+  [37.683, `Thirty Seven Euros And Sixty Eight Eurocents Only`],
+];
+
+const euroCurrencyOptions = {
+  name: 'Euro',
+  plural: 'Euros',
+  symbol: '€',
+  fractionalUnit: {
+    name: 'Eurocent',
+    plural: 'Eurocents',
+    symbol: '¢',
+  },
+};
+
+describe('Test Floats with options = { currency: true, currencyOptions }', () => {
+  test.concurrent.each(testFloatsWithEuroCurrency)('convert %d => %s', (input, expected) => {
+    expect(toWords.convert(input as number, { currency: true, currencyOptions: euroCurrencyOptions })).toBe(expected);
+  });
+});

--- a/dist/ToWords.js
+++ b/dist/ToWords.js
@@ -138,8 +138,9 @@ class ToWords {
         return words;
     }
     convertCurrency(number, options = {}) {
-        var _a, _b, _c;
+        var _a, _b, _c, _d;
         const locale = this.getLocale();
+        const currencyOptions = (_a = options.currencyOptions) !== null && _a !== void 0 ? _a : locale.config.currency;
         const isNegativeNumber = number < 0;
         if (isNegativeNumber) {
             number = Math.abs(number);
@@ -148,11 +149,11 @@ class ToWords {
         // Extra check for isFloat to overcome 1.999 rounding off to 2
         const split = number.toString().split('.');
         let words = [...this.convertInternal(Number(split[0]))];
-        if (locale.config.currency.plural) {
-            words.push(locale.config.currency.plural);
+        if (currencyOptions.plural) {
+            words.push(currencyOptions.plural);
         }
         const ignoreZero = this.isNumberZero(number) &&
-            (options.ignoreZeroCurrency || (((_a = locale.config) === null || _a === void 0 ? void 0 : _a.ignoreZeroInDecimals) && number !== 0));
+            (options.ignoreZeroCurrency || (((_b = locale.config) === null || _b === void 0 ? void 0 : _b.ignoreZeroInDecimals) && number !== 0));
         if (ignoreZero) {
             words = [];
         }
@@ -163,14 +164,14 @@ class ToWords {
                 wordsWithDecimal.push(locale.config.texts.and);
             }
             wordsWithDecimal.push(...this.convertInternal(Number(split[1]) * (!locale.config.decimalLengthWordMapping ? Math.pow(10, 2 - split[1].length) : 1)));
-            const decimalLengthWord = (_c = (_b = locale.config) === null || _b === void 0 ? void 0 : _b.decimalLengthWordMapping) === null || _c === void 0 ? void 0 : _c[split[1].length];
+            const decimalLengthWord = (_d = (_c = locale.config) === null || _c === void 0 ? void 0 : _c.decimalLengthWordMapping) === null || _d === void 0 ? void 0 : _d[split[1].length];
             if (decimalLengthWord === null || decimalLengthWord === void 0 ? void 0 : decimalLengthWord.length) {
                 wordsWithDecimal.push(decimalLengthWord);
             }
-            wordsWithDecimal.push(locale.config.currency.fractionalUnit.plural);
+            wordsWithDecimal.push(currencyOptions.fractionalUnit.plural);
         }
         else if (locale.config.decimalLengthWordMapping && words.length) {
-            wordsWithDecimal.push(locale.config.currency.fractionalUnit.plural);
+            wordsWithDecimal.push(currencyOptions.fractionalUnit.plural);
         }
         const isEmpty = words.length <= 0 && wordsWithDecimal.length <= 0;
         if (!isEmpty && isNegativeNumber) {

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,8 +1,19 @@
+export interface CurrencyOptions {
+    name: string;
+    plural: string;
+    symbol: string;
+    fractionalUnit: {
+        name: string;
+        plural: string;
+        symbol: string;
+    };
+}
 export declare type ConverterOptions = {
     currency?: boolean;
     ignoreDecimal?: boolean;
     ignoreZeroCurrency?: boolean;
     doNotAddOnly?: boolean;
+    currencyOptions?: CurrencyOptions;
 };
 export declare type ToWordsOptions = {
     localeCode?: string;
@@ -16,16 +27,7 @@ export declare type NumberWordMap = {
     value: string;
 };
 export declare type LocaleConfig = {
-    currency: {
-        name: string;
-        plural: string;
-        symbol: string;
-        fractionalUnit: {
-            name: string;
-            plural: string;
-            symbol: string;
-        };
-    };
+    currency: CurrencyOptions;
     texts: {
         and: string;
         minus: string;

--- a/src/ToWords.ts
+++ b/src/ToWords.ts
@@ -147,6 +147,8 @@ export class ToWords {
   protected convertCurrency(number: number, options: ConverterOptions = {}): string[] {
     const locale = this.getLocale();
 
+    const currencyOptions = options.currencyOptions ?? locale.config.currency;
+
     const isNegativeNumber = number < 0;
     if (isNegativeNumber) {
       number = Math.abs(number);
@@ -156,8 +158,8 @@ export class ToWords {
     // Extra check for isFloat to overcome 1.999 rounding off to 2
     const split = number.toString().split('.');
     let words = [...this.convertInternal(Number(split[0]))];
-    if (locale.config.currency.plural) {
-      words.push(locale.config.currency.plural);
+    if (currencyOptions.plural) {
+      words.push(currencyOptions.plural);
     }
     const ignoreZero =
       this.isNumberZero(number) &&
@@ -182,9 +184,9 @@ export class ToWords {
       if (decimalLengthWord?.length) {
         wordsWithDecimal.push(decimalLengthWord);
       }
-      wordsWithDecimal.push(locale.config.currency.fractionalUnit.plural);
+      wordsWithDecimal.push(currencyOptions.fractionalUnit.plural);
     } else if (locale.config.decimalLengthWordMapping && words.length) {
-      wordsWithDecimal.push(locale.config.currency.fractionalUnit.plural);
+      wordsWithDecimal.push(currencyOptions.fractionalUnit.plural);
     }
     const isEmpty = words.length <= 0 && wordsWithDecimal.length <= 0;
     if (!isEmpty && isNegativeNumber) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,20 @@
+export interface CurrencyOptions {
+  name: string;
+  plural: string;
+  symbol: string;
+  fractionalUnit: {
+    name: string;
+    plural: string;
+    symbol: string;
+  };
+}
+
 export type ConverterOptions = {
   currency?: boolean;
   ignoreDecimal?: boolean;
   ignoreZeroCurrency?: boolean;
   doNotAddOnly?: boolean; // applicable only when currency = true
+  currencyOptions?: CurrencyOptions; // applicable only when currency = true, overwrites options from locales
 };
 
 export type ToWordsOptions = {
@@ -20,16 +32,7 @@ export type NumberWordMap = {
 };
 
 export type LocaleConfig = {
-  currency: {
-    name: string;
-    plural: string;
-    symbol: string;
-    fractionalUnit: {
-      name: string;
-      plural: string;
-      symbol: string;
-    };
-  };
+  currency: CurrencyOptions;
   texts: {
     and: string;
     minus: string;


### PR DESCRIPTION
I've extended `converterOptions` to allow specifying currency overwrites without the need to define a new locale.

This can help in the cases where your target language is always the same (e.g English) but need to support few different currencies (for example USD + EUR). 