### PR TITLE
feat: Expose locales in an iterable capacity

### DIFF
--- a/dist/ToWords.d.ts
+++ b/dist/ToWords.d.ts
@@ -1,18 +1,20 @@
 import { ConstructorOf, ConverterOptions, LocaleInterface, ToWordsOptions } from './types';
+import LOCALES from './locales';
+export { LOCALES };
 export declare const DefaultConverterOptions: ConverterOptions;
 export declare const DefaultToWordsOptions: ToWordsOptions;
 export declare class ToWords {
-  private options;
-  private locale;
-  constructor(options?: ToWordsOptions);
-  getLocaleClass(): ConstructorOf<LocaleInterface>;
-  getLocale(): InstanceType<ConstructorOf<LocaleInterface>>;
-  convert(number: number, options?: ConverterOptions): string;
-  protected convertNumber(number: number): string[];
-  protected convertCurrency(number: number, options?: ConverterOptions): string[];
-  protected convertInternal(number: number, trailing?: boolean): string[];
-  toFixed(number: number, precision?: number): number;
-  isFloat(number: number | string): boolean;
-  isValidNumber(number: number | string): boolean;
-  isNumberZero(number: number): boolean;
+    private options;
+    private locale;
+    constructor(options?: ToWordsOptions);
+    getLocaleClass(): ConstructorOf<LocaleInterface>;
+    getLocale(): InstanceType<ConstructorOf<LocaleInterface>>;
+    convert(number: number, options?: ConverterOptions): string;
+    protected convertNumber(number: number): string[];
+    protected convertCurrency(number: number, options?: ConverterOptions): string[];
+    protected convertInternal(number: number, trailing?: boolean): string[];
+    toFixed(number: number, precision?: number): number;
+    isFloat(number: number | string): boolean;
+    isValidNumber(number: number | string): boolean;
+    isNumberZero(number: number): boolean;
 }

--- a/dist/ToWords.js
+++ b/dist/ToWords.js
@@ -3,32 +3,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ToWords = exports.DefaultToWordsOptions = exports.DefaultConverterOptions = void 0;
-const ee_EE_1 = __importDefault(require("./locales/ee-EE"));
-const en_AE_1 = __importDefault(require("./locales/en-AE"));
-const en_BD_1 = __importDefault(require("./locales/en-BD"));
-const en_GB_1 = __importDefault(require("./locales/en-GB"));
-const en_GH_1 = __importDefault(require("./locales/en-GH"));
-const en_IE_1 = __importDefault(require("./locales/en-IE"));
-const en_IN_1 = __importDefault(require("./locales/en-IN"));
-const en_MM_1 = __importDefault(require("./locales/en-MM"));
-const en_MU_1 = __importDefault(require("./locales/en-MU"));
-const en_NG_1 = __importDefault(require("./locales/en-NG"));
-const en_NP_1 = __importDefault(require("./locales/en-NP"));
-const en_PH_1 = __importDefault(require("./locales/en-PH"));
-const en_US_1 = __importDefault(require("./locales/en-US"));
-const es_ES_1 = __importDefault(require("./locales/es-ES"));
-const es_MX_1 = __importDefault(require("./locales/es-MX"));
-const fa_IR_1 = __importDefault(require("./locales/fa-IR"));
-const fr_BE_1 = __importDefault(require("./locales/fr-BE"));
-const fr_FR_1 = __importDefault(require("./locales/fr-FR"));
-const gu_IN_1 = __importDefault(require("./locales/gu-IN"));
-const hi_IN_1 = __importDefault(require("./locales/hi-IN"));
-const ko_KR_1 = __importDefault(require("./locales/ko-KR"));
-const mr_IN_1 = __importDefault(require("./locales/mr-IN"));
-const nl_SR_1 = __importDefault(require("./locales/nl-SR"));
-const pt_BR_1 = __importDefault(require("./locales/pt-BR"));
-const tr_TR_1 = __importDefault(require("./locales/tr-TR"));
+exports.ToWords = exports.DefaultToWordsOptions = exports.DefaultConverterOptions = exports.LOCALES = void 0;
+const locales_1 = __importDefault(require("./locales"));
+exports.LOCALES = locales_1.default;
 exports.DefaultConverterOptions = {
     currency: false,
     ignoreDecimal: false,
@@ -46,61 +23,11 @@ class ToWords {
         this.options = Object.assign({}, exports.DefaultToWordsOptions, options);
     }
     getLocaleClass() {
-        /* eslint-disable @typescript-eslint/no-var-requires */
-        switch (this.options.localeCode) {
-            case 'ee-EE':
-                return ee_EE_1.default;
-            case 'en-AE':
-                return en_AE_1.default;
-            case 'en-BD':
-                return en_BD_1.default;
-            case 'en-GB':
-                return en_GB_1.default;
-            case 'en-GH':
-                return en_GH_1.default;
-            case 'en-IE':
-                return en_IE_1.default;
-            case 'en-IN':
-                return en_IN_1.default;
-            case 'en-MM':
-                return en_MM_1.default;
-            case 'en-MU':
-                return en_MU_1.default;
-            case 'en-NG':
-                return en_NG_1.default;
-            case 'en-NP':
-                return en_NP_1.default;
-            case 'en-PH':
-                return en_PH_1.default;
-            case 'en-US':
-                return en_US_1.default;
-            case 'es-ES':
-                return es_ES_1.default;
-            case 'es-MX':
-                return es_MX_1.default;
-            case 'fa-IR':
-                return fa_IR_1.default;
-            case 'fr-BE':
-                return fr_BE_1.default;
-            case 'fr-FR':
-                return fr_FR_1.default;
-            case 'gu-IN':
-                return gu_IN_1.default;
-            case 'hi-IN':
-                return hi_IN_1.default;
-            case 'ko-KR':
-                return ko_KR_1.default;
-            case 'mr-IN':
-                return mr_IN_1.default;
-            case 'nl-SR':
-                return nl_SR_1.default;
-            case 'pt-BR':
-                return pt_BR_1.default;
-            case 'tr-TR':
-                return tr_TR_1.default;
+        if (!(this.options.localeCode in locales_1.default)) {
+            /* eslint-enable @typescript-eslint/no-var-requires */
+            throw new Error(`Unknown Locale "${this.options.localeCode}"`);
         }
-        /* eslint-enable @typescript-eslint/no-var-requires */
-        throw new Error(`Unknown Locale "${this.options.localeCode}"`);
+        return locales_1.default[this.options.localeCode];
     }
     getLocale() {
         if (this.locale === undefined) {

--- a/dist/locales/ee-EE.d.ts
+++ b/dist/locales/ee-EE.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-AE.d.ts
+++ b/dist/locales/en-AE.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-BD.d.ts
+++ b/dist/locales/en-BD.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-GB.d.ts
+++ b/dist/locales/en-GB.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-GH.d.ts
+++ b/dist/locales/en-GH.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-IE.d.ts
+++ b/dist/locales/en-IE.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-IN.d.ts
+++ b/dist/locales/en-IN.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-MM.d.ts
+++ b/dist/locales/en-MM.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-MU.d.ts
+++ b/dist/locales/en-MU.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-NG.d.ts
+++ b/dist/locales/en-NG.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-NP.d.ts
+++ b/dist/locales/en-NP.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-PH.d.ts
+++ b/dist/locales/en-PH.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/en-US.d.ts
+++ b/dist/locales/en-US.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/es-ES.d.ts
+++ b/dist/locales/es-ES.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/es-MX.d.ts
+++ b/dist/locales/es-MX.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/fa-IR.d.ts
+++ b/dist/locales/fa-IR.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/fr-BE.d.ts
+++ b/dist/locales/fr-BE.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/fr-FR.d.ts
+++ b/dist/locales/fr-FR.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/gu-IN.d.ts
+++ b/dist/locales/gu-IN.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/hi-IN.d.ts
+++ b/dist/locales/hi-IN.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/index.d.ts
+++ b/dist/locales/index.d.ts
@@ -1,0 +1,5 @@
+import { ConstructorOf, LocaleInterface } from '../types';
+declare const LOCALES: {
+    [key: string]: ConstructorOf<LocaleInterface>;
+};
+export default LOCALES;

--- a/dist/locales/index.js
+++ b/dist/locales/index.js
@@ -1,0 +1,58 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const ee_EE_1 = __importDefault(require("./ee-EE"));
+const en_AE_1 = __importDefault(require("./en-AE"));
+const en_BD_1 = __importDefault(require("./en-BD"));
+const en_GB_1 = __importDefault(require("./en-GB"));
+const en_GH_1 = __importDefault(require("./en-GH"));
+const en_IE_1 = __importDefault(require("./en-IE"));
+const en_IN_1 = __importDefault(require("./en-IN"));
+const en_MM_1 = __importDefault(require("./en-MM"));
+const en_MU_1 = __importDefault(require("./en-MU"));
+const en_NG_1 = __importDefault(require("./en-NG"));
+const en_NP_1 = __importDefault(require("./en-NP"));
+const en_PH_1 = __importDefault(require("./en-PH"));
+const en_US_1 = __importDefault(require("./en-US"));
+const es_ES_1 = __importDefault(require("./es-ES"));
+const es_MX_1 = __importDefault(require("./es-MX"));
+const fa_IR_1 = __importDefault(require("./fa-IR"));
+const fr_BE_1 = __importDefault(require("./fr-BE"));
+const fr_FR_1 = __importDefault(require("./fr-FR"));
+const gu_IN_1 = __importDefault(require("./gu-IN"));
+const hi_IN_1 = __importDefault(require("./hi-IN"));
+const ko_KR_1 = __importDefault(require("./ko-KR"));
+const mr_IN_1 = __importDefault(require("./mr-IN"));
+const nl_SR_1 = __importDefault(require("./nl-SR"));
+const pt_BR_1 = __importDefault(require("./pt-BR"));
+const tr_TR_1 = __importDefault(require("./tr-TR"));
+const LOCALES = {
+    'ee-EE': ee_EE_1.default,
+    'en-AE': en_AE_1.default,
+    'en-BD': en_BD_1.default,
+    'en-GB': en_GB_1.default,
+    'en-GH': en_GH_1.default,
+    'en-IE': en_IE_1.default,
+    'en-IN': en_IN_1.default,
+    'en-MM': en_MM_1.default,
+    'en-MU': en_MU_1.default,
+    'en-NG': en_NG_1.default,
+    'en-NP': en_NP_1.default,
+    'en-PH': en_PH_1.default,
+    'en-US': en_US_1.default,
+    'es-ES': es_ES_1.default,
+    'es-MX': es_MX_1.default,
+    'fa-IR': fa_IR_1.default,
+    'fr-BE': fr_BE_1.default,
+    'fr-FR': fr_FR_1.default,
+    'gu-IN': gu_IN_1.default,
+    'hi-IN': hi_IN_1.default,
+    'ko-KR': ko_KR_1.default,
+    'mr-IN': mr_IN_1.default,
+    'nl-SR': nl_SR_1.default,
+    'pt-BR': pt_BR_1.default,
+    'tr-TR': tr_TR_1.default,
+};
+exports.default = LOCALES;

--- a/dist/locales/ko-KR.d.ts
+++ b/dist/locales/ko-KR.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/mr-IN.d.ts
+++ b/dist/locales/mr-IN.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/nl-SR.d.ts
+++ b/dist/locales/nl-SR.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/pt-BR.d.ts
+++ b/dist/locales/pt-BR.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/locales/tr-TR.d.ts
+++ b/dist/locales/tr-TR.d.ts
@@ -1,4 +1,4 @@
 import { LocaleConfig, LocaleInterface } from '../types';
 export default class Locale implements LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,54 +1,54 @@
 export interface CurrencyOptions {
-  name: string;
-  plural: string;
-  symbol: string;
-  singular?: string;
-  fractionalUnit: {
     name: string;
     plural: string;
-    singular?: string;
     symbol: string;
-  };
+    singular?: string;
+    fractionalUnit: {
+        name: string;
+        plural: string;
+        singular?: string;
+        symbol: string;
+    };
 }
 export type ConverterOptions = {
-  currency?: boolean;
-  ignoreDecimal?: boolean;
-  ignoreZeroCurrency?: boolean;
-  doNotAddOnly?: boolean;
-  currencyOptions?: CurrencyOptions;
+    currency?: boolean;
+    ignoreDecimal?: boolean;
+    ignoreZeroCurrency?: boolean;
+    doNotAddOnly?: boolean;
+    currencyOptions?: CurrencyOptions;
 };
 export type ToWordsOptions = {
-  localeCode?: string;
-  converterOptions?: ConverterOptions;
+    localeCode?: string;
+    converterOptions?: ConverterOptions;
 };
 export interface ConstructorOf<T> {
-  new (...args: unknown[]): T;
+    new (...args: unknown[]): T;
 }
 export type NumberWordMap = {
-  number: number;
-  value: string | [string, string];
+    number: number;
+    value: string | [string, string];
 };
 export type LocaleConfig = {
-  currency: CurrencyOptions;
-  texts: {
-    and: string;
-    minus: string;
-    only: string;
-    point: string;
-  };
-  numberWordsMapping: NumberWordMap[];
-  exactWordsMapping?: NumberWordMap[];
-  namedLessThan1000?: boolean;
-  splitWord?: string;
-  ignoreZeroInDecimals?: boolean;
-  decimalLengthWordMapping?: Record<number, string>;
-  ignoreOneForWords?: string[];
-  pluralMark?: string;
-  pluralWords?: string[];
-  noSplitWordAfter?: string[];
-  onlyInFront?: boolean;
-  trim?: boolean;
+    currency: CurrencyOptions;
+    texts: {
+        and: string;
+        minus: string;
+        only: string;
+        point: string;
+    };
+    numberWordsMapping: NumberWordMap[];
+    exactWordsMapping?: NumberWordMap[];
+    namedLessThan1000?: boolean;
+    splitWord?: string;
+    ignoreZeroInDecimals?: boolean;
+    decimalLengthWordMapping?: Record<number, string>;
+    ignoreOneForWords?: string[];
+    pluralMark?: string;
+    pluralWords?: string[];
+    noSplitWordAfter?: string[];
+    onlyInFront?: boolean;
+    trim?: boolean;
 };
 export interface LocaleInterface {
-  config: LocaleConfig;
+    config: LocaleConfig;
 }

--- a/src/ToWords.ts
+++ b/src/ToWords.ts
@@ -1,29 +1,7 @@
 import { ConstructorOf, ConverterOptions, LocaleInterface, NumberWordMap, ToWordsOptions } from './types';
-import eeEE from './locales/ee-EE';
-import enAe from './locales/en-AE';
-import enBd from './locales/en-BD';
-import enGb from './locales/en-GB';
-import enGh from './locales/en-GH';
-import enIe from './locales/en-IE';
-import enIn from './locales/en-IN';
-import enMm from './locales/en-MM';
-import enMu from './locales/en-MU';
-import enNg from './locales/en-NG';
-import enNp from './locales/en-NP';
-import enPh from './locales/en-PH';
-import enUs from './locales/en-US';
-import esES from './locales/es-ES';
-import esMX from './locales/es-MX';
-import faIr from './locales/fa-IR';
-import frBe from './locales/fr-BE';
-import frFr from './locales/fr-FR';
-import guIn from './locales/gu-IN';
-import hiIn from './locales/hi-IN';
-import koKr from './locales/ko-KR';
-import mrIn from './locales/mr-IN';
-import nlSr from './locales/nl-SR';
-import ptBR from './locales/pt-BR';
-import trTr from './locales/tr-TR';
+import LOCALES from './locales';
+
+export { LOCALES };
 
 export const DefaultConverterOptions: ConverterOptions = {
   currency: false,
@@ -47,61 +25,11 @@ export class ToWords {
   }
 
   public getLocaleClass(): ConstructorOf<LocaleInterface> {
-    /* eslint-disable @typescript-eslint/no-var-requires */
-    switch (this.options.localeCode) {
-      case 'ee-EE':
-        return eeEE;
-      case 'en-AE':
-        return enAe;
-      case 'en-BD':
-        return enBd;
-      case 'en-GB':
-        return enGb;
-      case 'en-GH':
-        return enGh;
-      case 'en-IE':
-        return enIe;
-      case 'en-IN':
-        return enIn;
-      case 'en-MM':
-        return enMm;
-      case 'en-MU':
-        return enMu;
-      case 'en-NG':
-        return enNg;
-      case 'en-NP':
-        return enNp;
-      case 'en-PH':
-        return enPh;
-      case 'en-US':
-        return enUs;
-      case 'es-ES':
-        return esES;
-      case 'es-MX':
-        return esMX;
-      case 'fa-IR':
-        return faIr;
-      case 'fr-BE':
-        return frBe;
-      case 'fr-FR':
-        return frFr;
-      case 'gu-IN':
-        return guIn;
-      case 'hi-IN':
-        return hiIn;
-      case 'ko-KR':
-        return koKr;
-      case 'mr-IN':
-        return mrIn;
-      case 'nl-SR':
-        return nlSr;
-      case 'pt-BR':
-        return ptBR;
-      case 'tr-TR':
-        return trTr;
+    if (!(this.options.localeCode! in LOCALES)) {
+      /* eslint-enable @typescript-eslint/no-var-requires */
+      throw new Error(`Unknown Locale "${this.options.localeCode}"`);
     }
-    /* eslint-enable @typescript-eslint/no-var-requires */
-    throw new Error(`Unknown Locale "${this.options.localeCode}"`);
+    return LOCALES[this.options.localeCode!];
   }
 
   public getLocale(): InstanceType<ConstructorOf<LocaleInterface>> {

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,0 +1,57 @@
+import { ConstructorOf, LocaleInterface } from '../types';
+
+import eeEE from './ee-EE';
+import enAe from './en-AE';
+import enBd from './en-BD';
+import enGb from './en-GB';
+import enGh from './en-GH';
+import enIe from './en-IE';
+import enIn from './en-IN';
+import enMm from './en-MM';
+import enMu from './en-MU';
+import enNg from './en-NG';
+import enNp from './en-NP';
+import enPh from './en-PH';
+import enUs from './en-US';
+import esEs from './es-ES';
+import esMx from './es-MX';
+import faIr from './fa-IR';
+import frBe from './fr-BE';
+import frFr from './fr-FR';
+import guIn from './gu-IN';
+import hiIn from './hi-IN';
+import koKr from './ko-KR';
+import mrIn from './mr-IN';
+import nlSr from './nl-SR';
+import ptBR from './pt-BR';
+import trTr from './tr-TR';
+
+const LOCALES: { [key: string]: ConstructorOf<LocaleInterface> } = {
+  'ee-EE': eeEE,
+  'en-AE': enAe,
+  'en-BD': enBd,
+  'en-GB': enGb,
+  'en-GH': enGh,
+  'en-IE': enIe,
+  'en-IN': enIn,
+  'en-MM': enMm,
+  'en-MU': enMu,
+  'en-NG': enNg,
+  'en-NP': enNp,
+  'en-PH': enPh,
+  'en-US': enUs,
+  'es-ES': esEs,
+  'es-MX': esMx,
+  'fa-IR': faIr,
+  'fr-BE': frBe,
+  'fr-FR': frFr,
+  'gu-IN': guIn,
+  'hi-IN': hiIn,
+  'ko-KR': koKr,
+  'mr-IN': mrIn,
+  'nl-SR': nlSr,
+  'pt-BR': ptBR,
+  'tr-TR': trTr,
+};
+
+export default LOCALES;


### PR DESCRIPTION
I would like to build an app that supports _all_ locales implemented in this package, and I would rather not maintain a separate list of supported locales that I would have to keep track of, instead of just updating my dependencies. So I figured it'd make way more sense to hold each class constructor in a map instead of a single `switch` statement. 

Thoughts? I don't see any harm in this, outside of negligibly slower lookup time.